### PR TITLE
Add settings persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,8 +708,11 @@ name = "caps"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "directories",
+ "serde",
  "slint",
  "slint-build",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1040,6 +1043,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1576,6 +1600,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -3305,6 +3340,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3809,6 +3850,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,7 +4214,7 @@ dependencies = [
  "regex",
  "serde_json",
  "tar",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4704,6 +4756,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5043,6 +5110,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.102"
+directories = "6.0.0"
+serde = "1.0.228"
 slint = "1.16.1"
+toml = "1.1.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,22 +5,29 @@ use slint::LogicalSize;
 use tracing::{debug, error, warn};
 use tracing_subscriber::EnvFilter;
 
+use crate::settings::Settings;
+
+mod settings;
+
 slint::include_modules!();
+
+const APP_NAME: &str = "caps";
 
 fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("caps=info,slint=warn")),
+                .unwrap_or_else(|_| EnvFilter::new(format!("{APP_NAME}=info,slint=warn"))),
         )
         .init();
 
     debug!("starting app");
+    debug!("loading settings");
     let ctx = Rc::new(AppContext::new().unwrap_or_else(|err| {
         error!(error = %err, "failed to create app context");
         std::process::exit(1);
     }));
-    slint::set_xdg_app_id("caps")
+    slint::set_xdg_app_id(APP_NAME)
         .unwrap_or_else(|err| error!(error = %err, "failed to register XDG app ID"));
     debug!("implement UI callbacks");
     ctx.impl_callbacks();
@@ -34,26 +41,35 @@ fn main() {
     debug!("exiting app");
 }
 
-fn save_settings_and_exit() {
+fn save_settings_and_exit(ctx: &AppContext) {
+    ctx.settings
+        .save()
+        .unwrap_or_else(|err| error!(error = %err, "failed to save settings"));
+
     slint::quit_event_loop()
         .unwrap_or_else(|err| error!(error = %err, "error encountered while quitting app"));
 }
 
 struct AppContext {
     windows: AppWindows,
+    settings: Settings,
 }
 
 impl AppContext {
     fn new() -> Result<Self> {
         Ok(Self {
             windows: AppWindows::new()?,
+            settings: Settings::load_or_default(),
         })
     }
 
     fn impl_callbacks(self: &Rc<Self>) {
-        self.windows.main.window().on_close_requested(|| {
+        let close_ctx = Rc::downgrade(self);
+        self.windows.main.window().on_close_requested(move || {
             debug!("close requested");
-            save_settings_and_exit();
+            if let Some(ctx) = close_ctx.upgrade() {
+                save_settings_and_exit(&ctx);
+            }
             slint::CloseRequestResponse::HideWindow
         });
 
@@ -76,9 +92,12 @@ impl AppContext {
             }
         });
 
-        self.windows.main.on_quit(|| {
+        let quit_ctx = Rc::downgrade(self);
+        self.windows.main.on_quit(move || {
             debug!("quit requested");
-            save_settings_and_exit();
+            if let Some(ctx) = quit_ctx.upgrade() {
+                save_settings_and_exit(&ctx);
+            }
         });
 
         self.windows

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+
+use crate::APP_NAME;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Settings {
+    #[serde(skip)]
+    loaded_from: PathBuf,
+}
+
+impl Settings {
+    pub fn load_or_default() -> Self {
+        let path = ProjectDirs::from("", "", APP_NAME)
+            .map(|dirs| dirs.config_dir().join("settings.toml"))
+            .unwrap_or_else(|| PathBuf::from("settings.toml"));
+        let mut settings: Settings = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|contents| toml::from_str(&contents).ok())
+            .unwrap_or_default();
+        settings.loaded_from = path;
+        settings
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = if self.loaded_from.as_os_str().is_empty() {
+            ProjectDirs::from("", "", APP_NAME)
+                .map(|dirs| dirs.config_dir().join("settings.toml"))
+                .unwrap_or_else(|| PathBuf::from("settings.toml"))
+        } else {
+            self.loaded_from.clone()
+        };
+        if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create config dir at '{}'", parent.display())
+            })?;
+        }
+
+        let contents = toml::to_string_pretty(self).context("failed to serialize settings")?;
+        std::fs::write(&path, contents)
+            .with_context(|| format!("failed to write settings file {}", path.display()))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Introduce Settings that load from the XDG config dir (ProjectDirs) and serialize to TOML. Save settings on quit/close and wire Settings into AppContext. Add directories, serde and toml dependencies.